### PR TITLE
Drop the build flag from boost.

### DIFF
--- a/install
+++ b/install
@@ -97,8 +97,7 @@ do_install()
   # Prerequisites. All of these should in theory be covered by rosdep, but for various reasons
   # they're best installed in advance, due to needing a specific version, or specifying build
   # options, or whatever. Obviously it would be great to migrate these toward purely rosdep.
-  brew install cmake libyaml lz4 assimp
-  brew install boost --with-python
+  brew install boost boost-python cmake libyaml lz4 assimp
   brew reinstall fltk --devel # FLTK for El Capitan, see issue #12
 
   # Make opencv use numpy from pip rather than brew, see issue #14


### PR DESCRIPTION
This should let us use the bottles for boost. Note that the same change happened many moons ago in rosdep:

https://github.com/ros/rosdistro/commit/3646e5df9cb1076916924aea2a2df67b5f62189d