### PR TITLE
SIP: Check for all versions 10.11 or later

### DIFF
--- a/install
+++ b/install
@@ -166,8 +166,8 @@ do_install()
   echo "  source ${ROS_INSTALL_DIR}/setup.bash"
   echo
   
-  # Check for SIP if on El Capitan
-  if [[ `sw_vers -productVersion` == *"10.11"* ]]
+  # Check for SIP if on OSX/macOS 10.11 (El Capitan) or later
+  if [[ `sw_vers -productVersion` > "10.10" ]]
   then
     if `csrutil status | grep -q enabled`
     then


### PR DESCRIPTION
This abuses the string operator to suppose that future versions will have a string value which is "greater than" the test value. This is brittle and  will break after either an OSX/macOS major version bump (unlikely to be of concern) or after a minor version bump beyond 10.99 (also unlikely to be of
concern).

NOTE: Tested only on macOS Sierra.

Fixes https://github.com/mikepurvis/ros-install-osx/issues/65.