### PR TITLE
Downgrade Boost to 1.59.0 as a temp fix for #67

### DIFF
--- a/install
+++ b/install
@@ -102,10 +102,10 @@ do_install()
   # Temporary workaround for mikepurvis/ros-install-osx#67
   brew remove --force boost || true
   brew remove --force boost-python || true
-  # brew install boost159
-  # brew link --force boost159
-  # brew install boost-python159
-  # brew link --force boost-python159
+  brew install boost159
+  brew link --force --overwrite boost159
+  brew install boost-python159
+  brew link --force --overwrite boost-python159
 
   # ROS infrastructure tools
   brew install libyaml || true

--- a/install
+++ b/install
@@ -95,10 +95,13 @@ do_install()
   # Homebrew python gets us bottles for numpy, scipy, etc.
   brew tap homebrew/python
 
+  # Temporary workaround for boost, boost-python, pyside, shiboken
+  brew tap homebrew/versions
+  brew tap homebrew/boneyard
+
   # Temporary workaround for mikepurvis/ros-install-osx#67
   brew remove --force boost || true
   brew remove --force boost-python || true
-  brew tap homebrew/versions
   # brew install boost159
   # brew link --force boost159
   # brew install boost-python159

--- a/install
+++ b/install
@@ -95,6 +95,11 @@ do_install()
   # Homebrew python gets us bottles for numpy, scipy, etc.
   brew tap homebrew/python
 
+  # Temporary workaround for mikepurvis/ros-install-osx#67
+  brew remove --force boost || true
+  brew tap homebrew/versions
+  brew install homebrew/versions/boost159
+
   # ROS infrastructure tools
   brew install libyaml || true
   pip install -U setuptools rosdep rosinstall_generator wstool rosinstall catkin_tools bloom empy sphinx pycurl
@@ -165,7 +170,7 @@ do_install()
   echo
   echo "  source ${ROS_INSTALL_DIR}/setup.bash"
   echo
-  
+
   # Check for SIP if on OSX/macOS 10.11 (El Capitan) or later
   if [[ `sw_vers -productVersion` > "10.10" ]]
   then

--- a/install
+++ b/install
@@ -99,10 +99,10 @@ do_install()
   brew remove --force boost || true
   brew remove --force boost-python || true
   brew tap homebrew/versions
-  brew install boost159
-  brew link --force boost159
-  brew install boost-python159
-  brew link --force boost-python159
+  # brew install boost159
+  # brew link --force boost159
+  # brew install boost-python159
+  # brew link --force boost-python159
 
   # ROS infrastructure tools
   brew install libyaml || true

--- a/install
+++ b/install
@@ -118,7 +118,7 @@ do_install()
   fi
   if [ ! -f /etc/ros/rosdep/10-ros-install-osx.list ]; then
     echo "This sudo prompt adds the the brewed python rosdep yaml to /etc/ros/rosdep/10-ros-install-osx.list."
-    sudo sh -c "echo 'yaml https://raw.githubusercontent.com/mikepurvis/ros-install-osx/master/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
+    sudo sh -c "echo 'yaml https://raw.githubusercontent.com/spmaniato/ros-install-osx/downgrade_boost/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
   fi
   rosdep update
 

--- a/install
+++ b/install
@@ -99,14 +99,6 @@ do_install()
   brew tap homebrew/versions
   brew tap homebrew/boneyard
 
-  # Temporary workaround for mikepurvis/ros-install-osx#67
-  brew remove --force boost || true
-  brew remove --force boost-python || true
-  brew install boost159
-  brew link --force --overwrite boost159
-  brew install boost-python159
-  brew link --force --overwrite boost-python159
-
   # ROS infrastructure tools
   brew install libyaml || true
   pip install -U setuptools rosdep rosinstall_generator wstool rosinstall catkin_tools bloom empy sphinx pycurl
@@ -154,6 +146,14 @@ do_install()
 
   # Package dependencies.
   rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5
+
+  # Temporary workaround for mikepurvis/ros-install-osx#67
+  brew remove --force boost || true
+  brew remove --force boost-python || true
+  brew install boost159
+  brew link --force --overwrite boost159
+  brew install boost-python159
+  brew link --force --overwrite boost-python159
 
   # Clean out or create the install directory.
   if [ -d ${ROS_INSTALL_DIR} ]; then

--- a/install
+++ b/install
@@ -97,9 +97,12 @@ do_install()
 
   # Temporary workaround for mikepurvis/ros-install-osx#67
   brew remove --force boost || true
+  brew remove --force boost-python || true
   brew tap homebrew/versions
-  brew install homebrew/versions/boost159
+  brew install boost159
   brew link --force boost159
+  brew install boost-python159
+  brew link --force boost-python159
 
   # ROS infrastructure tools
   brew install libyaml || true

--- a/install
+++ b/install
@@ -99,6 +99,7 @@ do_install()
   brew remove --force boost || true
   brew tap homebrew/versions
   brew install homebrew/versions/boost159
+  brew link --force boost159
 
   # ROS infrastructure tools
   brew install libyaml || true

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -1,11 +1,11 @@
-boost:
-  osx:
-    homebrew:
-      packages: [homebrew/versions/boost159, homebrew/versions/boost-python159]
-boost-python:
-  osx:
-    homebrew:
-      packages: [homebrew/versions/boost-python159]
+# boost:
+#   osx:
+#     homebrew:
+#       packages: [homebrew/versions/boost159, homebrew/versions/boost-python159]
+# boost-python:
+#   osx:
+#     homebrew:
+#       packages: [homebrew/versions/boost-python159]
 gazebo:
   osx:
     homebrew:

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -28,3 +28,7 @@ python-scipy:
   osx:
     homebrew:
       packages: [homebrew/python/scipy]
+boost:
+  osx:
+    homebrew:
+      packages: [boost159, boost-python159]

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -1,3 +1,7 @@
+boost:
+  osx:
+    homebrew:
+      packages: [homebrew/versions/boost159, homebrew/versions/boost-python159]
 gazebo:
   osx:
     homebrew:
@@ -20,6 +24,10 @@ python-numpy:
   osx:
     homebrew:
       packages: [homebrew/python/numpy]
+python-qt-bindings:
+  osx:
+    homebrew:
+      packages: [homebrew/boneyard/pyside, homebrew/boneyard/shiboken, pyqt, sip]
 python-scapy:
   osx:
     homebrew:
@@ -28,7 +36,3 @@ python-scipy:
   osx:
     homebrew:
       packages: [homebrew/python/scipy]
-boost:
-  osx:
-    homebrew:
-      packages: [boost159, boost-python159]

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -2,6 +2,10 @@ boost:
   osx:
     homebrew:
       packages: [homebrew/versions/boost159, homebrew/versions/boost-python159]
+boost-python:
+  osx:
+    homebrew:
+      packages: [homebrew/versions/boost-python159]
 gazebo:
   osx:
     homebrew:


### PR DESCRIPTION
Hacky workaround for #67

FYI, the previous CI build ([72.1, `gazebo_ros`](https://travis-ci.org/mikepurvis/ros-install-osx/jobs/167438303)) failed due to Gazebo, not #67; compilation didn't even start.

```
ERROR: the following rosdeps failed to install
  homebrew: command [brew install gazebo7] failed
```

Update: ([72.3, `ros_base`](https://travis-ci.org/mikepurvis/ros-install-osx/jobs/167438305)) does fail because of #67 though.
