### PR TITLE
Sierra indigo issue73

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     # Desktop full of LTS on 10.12
     - os: osx
       osx_image: xcode8.1
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop-full
+      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
 
     # Building anything GUI from Kinetic fails due to qt4/5 issues.
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ matrix:
       osx_image: xcode8
       env: ROS_DISTRO=kinetic ROS_CONFIGURATION=ros_base
 
-cache:
-  directories:
-    - $HOME/Library/Caches/pip
-    - $HOME/Library/Caches/Homebrew
+cache: false
+#  directories:
+#    - $HOME/Library/Caches/pip
+#    - $HOME/Library/Caches/Homebrew
 
 script:
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: generic
 matrix:
   include:
     # OSRF has bottles of Gazebo on Yosemite, so test gazebo_ros on that.
-    - os: osx
-      osx_image: xcode7.3
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
+#    - os: osx
+#      osx_image: xcode7.3
+#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
 
     # Check up to rviz on El Capitan (this build sometimes times out).
-    - os: osx
-      osx_image: xcode8
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
+#    - os: osx
+#      osx_image: xcode8
+#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
 
     # Desktop full LTS on 10.12
     - os: osx
@@ -31,5 +31,4 @@ before_script:
   - rm -f /usr/local/bin/f2py && rm -rf /usr/local/lib/python2.7/site-packages/numpy
 
 script:
-  - brew test-bot --fast
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,5 @@ before_script:
   - rm -f /usr/local/bin/f2py && rm -rf /usr/local/lib/python2.7/site-packages/numpy
 
 script:
+  - brew test-bot --fast
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: generic
 matrix:
   include:
     # OSRF has bottles of Gazebo on Yosemite, so test gazebo_ros on that.
-#    - os: osx
-#      osx_image: xcode7.3
-#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
+    - os: osx
+      osx_image: xcode7.3
+      env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
 
     # Check up to rviz on El Capitan (this build sometimes times out).
-#    - os: osx
-#      osx_image: xcode8
-#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
+    - os: osx
+      osx_image: xcode8
+      env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
 
     # Desktop full LTS on 10.12
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ cache:
 
 before_script:
   - rm -f /usr/local/bin/f2py && rm -rf /usr/local/lib/python2.7/site-packages/numpy
+  - rm -f /usr/local/include/c++
 
 script:
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,20 @@ matrix:
       osx_image: xcode8
       env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
 
-    # Desktop full of LTS on 10.12
-    - os: osx
-      osx_image: xcode8.1
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
+    # Desktop full LTS on 10.12
+#    - os: osx
+#      osx_image: xcode8.1
+#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
 
     # Building anything GUI from Kinetic fails due to qt4/5 issues.
     - os: osx
       osx_image: xcode8
       env: ROS_DISTRO=kinetic ROS_CONFIGURATION=ros_base
 
-cache: false
-#  directories:
-#    - $HOME/Library/Caches/pip
-#    - $HOME/Library/Caches/Homebrew
+cache:
+  directories:
+    - $HOME/Library/Caches/pip
+    - $HOME/Library/Caches/Homebrew
 
 script:
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
     # Desktop full LTS on 10.12
     - os: osx
       osx_image: xcode8.1
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
+      env: ROS_DISTRO=indigo ROS_CONFIGURATION=ros_base
+#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
 
     # Building anything GUI from Kinetic fails due to qt4/5 issues.
 #    - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     # OSRF has bottles of Gazebo on Yosemite, so test gazebo_ros on that.
     - os: osx
-      osx_image: xcode7
+      osx_image: xcode7.3
       env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
 
     # Check up to rviz on El Capitan (this build sometimes times out).

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
       env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
 
     # Desktop full LTS on 10.12
-#    - os: osx
-#      osx_image: xcode8.1
-#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
+    - os: osx
+      osx_image: xcode8.1
+      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
 
     # Building anything GUI from Kinetic fails due to qt4/5 issues.
     - os: osx
@@ -25,7 +25,7 @@ matrix:
 cache:
   directories:
     - $HOME/Library/Caches/pip
-    - $HOME/Library/Caches/Homebrew
+#    - $HOME/Library/Caches/Homebrew
 
 script:
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
       osx_image: xcode8
       env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
 
+    # Desktop full of LTS on 10.12
+    - os: osx
+      osx_image: xcode8.1
+      env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop-full
+
     # Building anything GUI from Kinetic fails due to qt4/5 issues.
     - os: osx
       osx_image: xcode8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: generic
 matrix:
   include:
     # OSRF has bottles of Gazebo on Yosemite, so test gazebo_ros on that.
-    - os: osx
-      osx_image: xcode7.3
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
+#    - os: osx
+#      osx_image: xcode7.3
+#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
 
     # Check up to rviz on El Capitan (this build sometimes times out).
-    - os: osx
-      osx_image: xcode8
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
+#    - os: osx
+#      osx_image: xcode8
+#      env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
 
     # Desktop full LTS on 10.12
     - os: osx
@@ -18,14 +18,17 @@ matrix:
       env: ROS_DISTRO=indigo ROS_CONFIGURATION=desktop_full
 
     # Building anything GUI from Kinetic fails due to qt4/5 issues.
-    - os: osx
-      osx_image: xcode8
-      env: ROS_DISTRO=kinetic ROS_CONFIGURATION=ros_base
+#    - os: osx
+#      osx_image: xcode8
+#      env: ROS_DISTRO=kinetic ROS_CONFIGURATION=ros_base
 
 cache:
   directories:
     - $HOME/Library/Caches/pip
-#    - $HOME/Library/Caches/Homebrew
+    - $HOME/Library/Caches/Homebrew
+
+before_script:
+  - rm -f /usr/local/bin/f2py
 
 script:
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 before_script:
-  - rm -f /usr/local/bin/f2py
+  - rm -f /usr/local/bin/f2py && rm -rf /usr/local/lib/python2.7/site-packages/numpy
 
 script:
   - ./install

--- a/install
+++ b/install
@@ -98,7 +98,7 @@ do_install()
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
   OSX_PRODUCT_VERSION=`sw_vers -productVersion`
   echo "OSX Product version: " ${OSX_PRODUCT_VERSION}
-  if [[ ${OSX_PRODUCT_VERSION} > "10.11" ]]
+  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.12" ]]
   then
     echo "Installing custom Sierra qt4."
     brew install lloydc99/qt4/qt
@@ -194,7 +194,7 @@ do_install()
   echo
 
   # Check for SIP if on OSX/macOS 10.11 (El Capitan) or later
-  if [[ `sw_vers -productVersion` > "10.10" ]]
+  if [[ "${OSX_PRODUCT_VERSION}" > "10.10" ]]
   then
     if `csrutil status | grep -q enabled`
     then

--- a/install
+++ b/install
@@ -87,24 +87,29 @@ do_install()
   brew tap ros/deps
 
   # This tap gives us formulae for Gazebo and its dependencies, including SDF.
-  brew tap osrf/simulation
+  brew tap lloydc99/simulation
+  brew tap cartr/qt4
 
   # Homebrew science gives us vtk and PCL, among other things.
   brew tap homebrew/science
 
+  # Deprecated tap
   # Homebrew python gets us bottles for numpy, scipy, etc.
-  brew tap homebrew/python
+  #brew tap homebrew/python
 
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
   OSX_PRODUCT_VERSION=`sw_vers -productVersion`
   echo "OSX Product version: " ${OSX_PRODUCT_VERSION}
 
-  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.10" ]]
-  then
-    echo "Installing custom El Capitan/Sierra qt4 with pyside."
-    brew tap lloydc99/qt4
-    brew install lloydc99/qt4/qt
-  fi
+#  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.10" ]]
+#  then
+#    echo "Installing custom El Capitan/Sierra qt4 with pyside."
+#    brew tap lloydc99/qt4
+#    brew install lloydc99/qt4/qt
+#    echo "Installing custom El Capitan/Sierra simulation with newer bottles."
+#    brew tap lloydc99/rethink
+#    brew install lloydc99/qt4/simbody
+#  fi
 
   # ROS infrastructure tools
   brew install libyaml || true
@@ -116,8 +121,8 @@ do_install()
     sudo rosdep init
   fi
   if [ ! -f /etc/ros/rosdep/10-ros-install-osx.list ]; then
-    echo "This sudo prompt adds the the brewed python rosdep yaml to /etc/ros/rosdep/10-ros-install-osx.list."
-    sudo sh -c "echo 'yaml https://raw.githubusercontent.com/mikepurvis/ros-install-osx/master/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
+    echo "This sudo prompt adds the brewed python rosdep and legacy qt4 yaml to /etc/ros/rosdep/10-ros-install-osx.list."
+    sudo sh -c "echo 'yaml https://gist.githubusercontent.com/lloydc99/827e2f2fad3c97de11687121301c1ce5/raw/1061326d022c3e4f056e38040b1260c352a613c7/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
   fi
   rosdep update
 
@@ -167,7 +172,7 @@ do_install()
 
   # Fix for strange lack of nosetests in osx, kindof hackish
   if [ -z `which nosetests` ]; then
-    ln -s /usr/local/Cellar/matplotlib/$(python -c "import matplotlib; print matplotlib.__version__")/libexec/bin/nosetests /usr/local/bin
+    ln -s /usr/local/Cellar/numpy/$(python -c "import numpy; print numpy.__version__")/libexec/nose/bin/nosetests /usr/local/bin
   fi
 
   # Clean out or create the install directory.

--- a/install
+++ b/install
@@ -102,7 +102,6 @@ do_install()
   then
     echo "Installing custom Sierra qt4."
     brew install lloydc99/qt4/qt
-    SKIP_KEYS="--skip-keys=pyqt"
   fi
 
   # ROS infrastructure tools
@@ -162,7 +161,7 @@ do_install()
   fi
 
   # Package dependencies.
-  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 ${SKIP_KEYS}
+  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 --skip-keys=pyqt
 
   # Fix for strange lack of nosetests in osx, kindof hackish
   if [ -z `which nosetests` ]; then

--- a/install
+++ b/install
@@ -86,30 +86,21 @@ do_install()
   # Gives us console_bridge, urdfdom, and gtest.
   brew tap ros/deps
 
-  # This tap gives us formulae for Gazebo and its dependencies, including SDF.
-  brew tap lloydc99/simulation
-  brew tap cartr/qt4
-
   # Homebrew science gives us vtk and PCL, among other things.
   brew tap homebrew/science
-
-  # Deprecated tap
-  # Homebrew python gets us bottles for numpy, scipy, etc.
-  #brew tap homebrew/python
 
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
   OSX_PRODUCT_VERSION=`sw_vers -productVersion`
   echo "OSX Product version: " ${OSX_PRODUCT_VERSION}
 
-#  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.10" ]]
-#  then
-#    echo "Installing custom El Capitan/Sierra qt4 with pyside."
-#    brew tap lloydc99/qt4
-#    brew install lloydc99/qt4/qt
-#    echo "Installing custom El Capitan/Sierra simulation with newer bottles."
-#    brew tap lloydc99/rethink
-#    brew install lloydc99/qt4/simbody
-#  fi
+ if [[ ! "${OSX_PRODUCT_VERSION}" < "10.10" ]]
+ then
+   echo "Installing custom El Capitan/Sierra qt4 with pyside."
+   brew tap cartr/qt4
+   #brew install cartr/qt4/qt
+   echo "Installing custom El Capitan/Sierra simulation with newer bottles."
+   brew tap lloydc99/simulation
+ fi
 
   # ROS infrastructure tools
   brew install libyaml || true
@@ -120,9 +111,10 @@ do_install()
     echo "This sudo prompt is to initialize rosdep (creates the /etc/ros/rosdep path)."
     sudo rosdep init
   fi
+
   if [ ! -f /etc/ros/rosdep/10-ros-install-osx.list ]; then
     echo "This sudo prompt adds the brewed python rosdep and legacy qt4 yaml to /etc/ros/rosdep/10-ros-install-osx.list."
-    sudo sh -c "echo 'yaml https://gist.githubusercontent.com/lloydc99/827e2f2fad3c97de11687121301c1ce5/raw/1061326d022c3e4f056e38040b1260c352a613c7/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
+    sudo sh -c "echo 'yaml https://gist.githubusercontent.com/lloydc99/827e2f2fad3c97de11687121301c1ce5/raw/39e13ebe4d6cdee0521bac33bdc6e7bb3cb717e5/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
   fi
   rosdep update
 

--- a/install
+++ b/install
@@ -89,6 +89,8 @@ do_install()
   # Homebrew science gives us vtk and PCL, among other things.
   brew tap homebrew/science
 
+  brew tap lloydc99/simulation
+
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
   OSX_PRODUCT_VERSION=`sw_vers -productVersion`
   echo "OSX Product version: " ${OSX_PRODUCT_VERSION}
@@ -146,17 +148,6 @@ do_install()
     pushd src/catkin/cmake
     curl https://raw.githubusercontent.com/ros/catkin/8a47f4eceb4954beb4a5b38b50793d0bbe2c96cf/cmake/catkinConfig.cmake.in > catkinConfig.cmake.in
     popd
-  fi
-
-  # Fix header problem in ros_comm until patch is pushed into indigo.
-  # https://github.com/ros/ros_comm/commit/74674c49a64abbdcdd5aeea016997af2959c6f05
-  if [ "$ROS_DISTRO" == "indigo" ]; then
-    echo "Fix header problem in ros_comm indigo until patch is pushed."
-    if [ -d src/ros_comm/rosconsole ]; then
-      pushd src/ros_comm/rosconsole
-      curl https://gist.githubusercontent.com/lloydc99/da3b16f8afe49dd5b059dcf19f79ddc6/raw/ec566b0aac2e914164d2262f72182f9a171c3f94/ros_comm_vector.patch | patch -p1
-      popd
-    fi
   fi
 
   # Package dependencies.

--- a/install
+++ b/install
@@ -95,6 +95,9 @@ do_install()
   # Homebrew python gets us bottles for numpy, scipy, etc.
   brew tap homebrew/python
 
+  # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
+  brew install cartr/qt4/qt
+
   # ROS infrastructure tools
   brew install libyaml || true
   pip install -U setuptools rosdep rosinstall_generator wstool rosinstall catkin_tools bloom empy sphinx pycurl
@@ -140,8 +143,21 @@ do_install()
     popd
   fi
 
+  # Fix header problem in ros_comm indigo until patch is pushed.
+  echo "Fix header problem in ros_comm indigo until patch is pushed."
+  if [ -d src/ros_comm/rosconsole ]; then
+    pushd src/ros_comm/rosconsole
+    curl https://gist.githubusercontent.com/lloydc99/da3b16f8afe49dd5b059dcf19f79ddc6/raw/ec566b0aac2e914164d2262f72182f9a171c3f94/ros_comm_vector.patch | patch -p1
+    popd
+  fi
+
   # Package dependencies.
-  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5
+  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 --skip-keys=pyqt
+
+  # Fix for strange lack of nosetests in osx
+  if [ -z `which nosetests` ]; then
+    ln -s /usr/local/Cellar/matplotlib/1.5.1/libexec/bin/nosetests /usr/local/bin
+  fi
 
   # Clean out or create the install directory.
   if [ -d ${ROS_INSTALL_DIR} ]; then
@@ -154,6 +170,7 @@ do_install()
 
   # Parallel build.
   catkin config --install  --install-space ${ROS_INSTALL_DIR} --cmake-args \
+    -DCMAKE_FIND_FRAMEWORK=LAST \
     -DCATKIN_ENABLE_TESTING=1 \
     -DCMAKE_BUILD_TYPE=Release \
     -DPYTHON_LIBRARY=$(python -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
@@ -165,7 +182,7 @@ do_install()
   echo
   echo "  source ${ROS_INSTALL_DIR}/setup.bash"
   echo
-  
+
   # Check for SIP if on OSX/macOS 10.11 (El Capitan) or later
   if [[ `sw_vers -productVersion` > "10.10" ]]
   then

--- a/install
+++ b/install
@@ -102,6 +102,7 @@ do_install()
   then
     echo "Installing custom Sierra qt4."
     brew install lloydc99/qt4/qt
+    SKIP_PYQT="--skip-keys=pyqt"
   fi
 
   # ROS infrastructure tools
@@ -161,7 +162,7 @@ do_install()
   fi
 
   # Package dependencies.
-  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 --skip-keys=pyqt
+  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 ${SKIP_PYQT}
 
   # Fix for strange lack of nosetests in osx, kindof hackish
   if [ -z `which nosetests` ]; then

--- a/install
+++ b/install
@@ -98,10 +98,12 @@ do_install()
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
   OSX_PRODUCT_VERSION=`sw_vers -productVersion`
   echo "OSX Product version: " ${OSX_PRODUCT_VERSION}
-  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.11" ]]
+
+  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.10" ]]
   then
-    echo "Installing custom Sierra qt4."
+    echo "Installing custom El Capitan/Sierra qt4 with pyside."
     brew tap lloydc99/qt4
+    brew install lloydc99/qt4/qt
   fi
 
   # ROS infrastructure tools

--- a/install
+++ b/install
@@ -98,7 +98,7 @@ do_install()
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
   if [[ `sw_vers -productVersion` > "10.11" ]]
   then
-    brew install cartr/qt4/qt
+    brew install lloydc99/qt4/qt
     SKIP_KEYS="--skip-keys=pyqt"
   fi
 

--- a/install
+++ b/install
@@ -96,8 +96,11 @@ do_install()
   brew tap homebrew/python
 
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
-  if [[ `sw_vers -productVersion` > "10.11" ]]
+  OSX_PRODUCT_VERSION=`sw_vers -productVersion`
+  echo "OSX Product version: " ${OSX_PRODUCT_VERSION}
+  if [[ ${OSX_PRODUCT_VERSION} > "10.11" ]]
   then
+    echo "Installing custom Sierra qt4."
     brew install lloydc99/qt4/qt
     SKIP_KEYS="--skip-keys=pyqt"
   fi

--- a/install
+++ b/install
@@ -163,7 +163,7 @@ do_install()
 
   # Fix for strange lack of nosetests in osx, kindof hackish
   if [ -z `which nosetests` ]; then
-    ln -s /usr/local/Cellar/matplotlib/1.5.1/libexec/bin/nosetests /usr/local/bin
+    ln -s /usr/local/Cellar/matplotlib/$(python -c "import matplotlib; print matplotlib.__version__")/libexec/bin/nosetests /usr/local/bin
   fi
 
   # Clean out or create the install directory.

--- a/install
+++ b/install
@@ -99,6 +99,7 @@ do_install()
   if [[ `sw_vers -productVersion` > "10.11" ]]
   then
     brew install cartr/qt4/qt
+    SKIP_KEYS="--skip-keys=pyqt"
   fi
 
   # ROS infrastructure tools
@@ -158,10 +159,6 @@ do_install()
   fi
 
   # Package dependencies.
-  if [[ `sw_vers -productVersion` > "10.11" ]]; then
-    SKIP_KEYS="--skip-keys=pyqt"
-  fi
-
   rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 ${SKIP_KEYS}
 
   # Fix for strange lack of nosetests in osx, kindof hackish

--- a/install
+++ b/install
@@ -101,7 +101,7 @@ do_install()
   if [[ ! "${OSX_PRODUCT_VERSION}" < "10.12" ]]
   then
     echo "Installing custom Sierra qt4."
-    brew install lloydc99/qt4/qt
+    brew tap lloydc99/qt4
     SKIP_PYQT="--skip-keys=pyqt"
   fi
 

--- a/install
+++ b/install
@@ -98,11 +98,10 @@ do_install()
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
   OSX_PRODUCT_VERSION=`sw_vers -productVersion`
   echo "OSX Product version: " ${OSX_PRODUCT_VERSION}
-  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.12" ]]
+  if [[ ! "${OSX_PRODUCT_VERSION}" < "10.11" ]]
   then
     echo "Installing custom Sierra qt4."
     brew tap lloydc99/qt4
-    SKIP_PYQT="--skip-keys=pyqt"
   fi
 
   # ROS infrastructure tools
@@ -162,7 +161,7 @@ do_install()
   fi
 
   # Package dependencies.
-  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 ${SKIP_PYQT}
+  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5
 
   # Fix for strange lack of nosetests in osx, kindof hackish
   if [ -z `which nosetests` ]; then

--- a/install
+++ b/install
@@ -96,7 +96,10 @@ do_install()
   brew tap homebrew/python
 
   # Sierra no longer has a working qt4 so use this private version until the issue is resolved.
-  brew install cartr/qt4/qt
+  if [[ `sw_vers -productVersion` > "10.11" ]]
+  then
+    brew install cartr/qt4/qt
+  fi
 
   # ROS infrastructure tools
   brew install libyaml || true
@@ -143,18 +146,25 @@ do_install()
     popd
   fi
 
-  # Fix header problem in ros_comm indigo until patch is pushed.
-  echo "Fix header problem in ros_comm indigo until patch is pushed."
-  if [ -d src/ros_comm/rosconsole ]; then
-    pushd src/ros_comm/rosconsole
-    curl https://gist.githubusercontent.com/lloydc99/da3b16f8afe49dd5b059dcf19f79ddc6/raw/ec566b0aac2e914164d2262f72182f9a171c3f94/ros_comm_vector.patch | patch -p1
-    popd
+  # Fix header problem in ros_comm until patch is pushed into indigo.
+  # https://github.com/ros/ros_comm/commit/74674c49a64abbdcdd5aeea016997af2959c6f05
+  if [ "$ROS_DISTRO" == "indigo" ]; then
+    echo "Fix header problem in ros_comm indigo until patch is pushed."
+    if [ -d src/ros_comm/rosconsole ]; then
+      pushd src/ros_comm/rosconsole
+      curl https://gist.githubusercontent.com/lloydc99/da3b16f8afe49dd5b059dcf19f79ddc6/raw/ec566b0aac2e914164d2262f72182f9a171c3f94/ros_comm_vector.patch | patch -p1
+      popd
+    fi
   fi
 
   # Package dependencies.
-  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 --skip-keys=pyqt
+  if [[ `sw_vers -productVersion` > "10.11" ]]; then
+    SKIP_KEYS="--skip-keys=pyqt"
+  fi
 
-  # Fix for strange lack of nosetests in osx
+  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5 ${SKIP_KEYS}
+
+  # Fix for strange lack of nosetests in osx, kindof hackish
   if [ -z `which nosetests` ]; then
     ln -s /usr/local/Cellar/matplotlib/1.5.1/libexec/bin/nosetests /usr/local/bin
   fi

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -1,7 +1,31 @@
+libqt4:
+  osx:
+    homebrew:
+      packages: [cartr/qt4/qt]
+libqt4-dev:
+  osx:
+    homebrew:
+      packages: [cartr/qt4/qt]
+libqt4-opengl-dev:
+  osx:
+    homebrew:
+      packages: [cartr/qt4/qt]
+qt4-qmake:
+  osx:
+    homebrew:
+      packages: [cartr/qt4/qt]
+python-qt-bindings:
+  osx:
+    homebrew:
+      packages: [cartr/qt4/pyside, cartr/qt4/shiboken, cartr/qt4/pyqt]
+python-qt-bindings-gl:
+  osx:
+    homebrew:
+      packages: [cartr/qt4/pyqt]
 gazebo:
   osx:
     homebrew:
-      packages: [gazebo7]
+      packages: [lloydc99/simulation/gazebo7]
 python:
   osx:
     homebrew:
@@ -11,20 +35,12 @@ python:
 python-imaging:
   osx:
     homebrew:
-      packages: [homebrew/python/pillow]
+      packages: [homebrew/science/pillow]
 python-matplotlib:
   osx:
     homebrew:
-      packages: [homebrew/python/matplotlib]
-python-numpy:
-  osx:
-    homebrew:
-      packages: [homebrew/python/numpy]
-python-scapy:
-  osx:
-    homebrew:
-      packages: [homebrew/python/scapy]
+      packages: [homebrew/science/matplotlib]
 python-scipy:
   osx:
     homebrew:
-      packages: [homebrew/python/scipy]
+      packages: [scipy]


### PR DESCRIPTION
Include private version of qt4 for Sierra since it is not provided by main brew.

Patch bug in include headers in ros_console until fix is moved back to indigo.

Add a link to nosetests because it does not seem to be in the brew path.

Change the default search order for headers to look for OSX Frameworks last to get around issue #73. 