### PR TITLE
WIP: Update to build Lunar + QT5 + Ogre 1.9 + Gazebo 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,9 @@ language: generic
 
 matrix:
   include:
-    # OSRF has bottles of Gazebo on Yosemite, so test gazebo_ros on that.
-    - os: osx
-      osx_image: xcode7
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=gazebo_ros
-
-    # Check up to rviz on El Capitan (this build sometimes times out).
     - os: osx
       osx_image: xcode8
-      env: ROS_DISTRO=indigo ROS_CONFIGURATION=rviz
-
-    # Building anything GUI from Kinetic fails due to qt4/5 issues.
-    - os: osx
-      osx_image: xcode8
-      env: ROS_DISTRO=kinetic ROS_CONFIGURATION=ros_base
-
-cache:
-  directories:
-    - $HOME/Library/Caches/pip
-    - $HOME/Library/Caches/Homebrew
+      env: ROS_CONFIGURATION=rviz
 
 script:
   - ./install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - os: osx
       osx_image: xcode8
-      env: ROS_CONFIGURATION=rviz
+      env: ROS_CONFIGURATION=rviz PATH=/usr/local/bin:/usr/bin:/usr/sbin:/bin
 
 script:
   - ./install

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ ros-install-osx   [![Build Status](https://travis-ci.org/mikepurvis/ros-install-
 ===============
 
 This repo aims to maintain a usable, scripted, up-to-date installation procedure for
-[ROS](http://ros.org). The intent is that the `install` script may be executed on a
-bare Yosemite or El Capitan machine and produce a working desktop_full installation,
-including RQT, rviz, and Gazebo.
+[ROS](http://ros.org), currently Lunar. The intent is that the `install` script may
+be executed on a El Capitan or newer machine and produce a working desktop_full
+installation, including RQT, rviz, and Gazebo.
 
 This is the successor to my [popular gist on the same topic][1].
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ This is the successor to my [popular gist on the same topic][1].
 Usage
 -----
 
-    curl https://raw.githubusercontent.com/mikepurvis/ros-install-osx/master/install | bash
-
-or
-
 ```shell
 git clone https://github.com/mikepurvis/ros-install-osx.git
 cd ros-install-osx

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  xcode:
+    version: 8.2
+
+compile:
+  override:
+    - ./install

--- a/install
+++ b/install
@@ -22,7 +22,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-ROS_DISTRO=${ROS_DISTRO:-indigo}
+ROS_DISTRO=${ROS_DISTRO:-lunar}
 ROS_CONFIGURATION=${ROS_CONFIGURATION:-desktop_full}
 ROS_EXTRA_PACKAGES=${ROS_EXTRA_PACKAGES:-}
 ROS_INSTALL_DIR=${ROS_INSTALL_DIR:-/opt/ros/${ROS_DISTRO}}
@@ -77,7 +77,7 @@ do_install()
   fi
 
   # Brewed Python
-  if [ $(which python) != "/usr/local/bin/python" ]; then
+  if [ $(which python2) != "/usr/local/bin/python2" ]; then
     brew install python
     mkdir -p ~/Library/Python/2.7/lib/python/site-packages
     echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
@@ -92,21 +92,25 @@ do_install()
   # Homebrew science gives us vtk and PCL, among other things.
   brew tap homebrew/science
 
-  # Homebrew python gets us bottles for numpy, scipy, etc.
-  brew tap homebrew/python
-
   # ROS infrastructure tools
   brew install libyaml || true
-  pip install -U setuptools rosdep rosinstall_generator wstool rosinstall catkin_tools bloom empy sphinx pycurl
+  pip2 install -U setuptools rosdep rosinstall_generator wstool rosinstall catkin_tools bloom empy sphinx pycurl
+
+  # Rosdep has an issue detecting that qt5 is correctly installed, so preinstall it.
+  brew install qt5 pyqt5 sip
+  brew link qt5 --force
+
+  # Mock out python and pip so that we get the brewed versions when rosdep and other programs call them.
+  export PATH=$(pwd)/shim:$PATH
 
   # Initialize and update rosdep
   if [ ! -d /etc/ros/rosdep/ ]; then
     echo "This sudo prompt is to initialize rosdep (creates the /etc/ros/rosdep path)."
     sudo rosdep init
   fi
-  if [ ! -f /etc/ros/rosdep/10-ros-install-osx.list ]; then
-    echo "This sudo prompt adds the the brewed python rosdep yaml to /etc/ros/rosdep/10-ros-install-osx.list."
-    sudo sh -c "echo 'yaml https://raw.githubusercontent.com/mikepurvis/ros-install-osx/master/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
+  if [ ! -f /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list ]; then
+    echo "This sudo prompt adds the the brewed python rosdep yaml to /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
+    sudo sh -c "echo 'yaml file://$(pwd)/rosdeps.yaml osx' > /etc/ros/rosdep/sources.list.d/10-ros-install-osx.list"
   fi
   rosdep update
 
@@ -121,17 +125,6 @@ do_install()
   # Standard source install
   rosinstall_generator ${ROS_CONFIGURATION} ${ROS_EXTRA_PACKAGES} --rosdistro ${ROS_DISTRO} --deps --tar > ${WS}.rosinstall
   wstool init -j8 src ${WS}.rosinstall
-
-  # Grabbing these older meshes allows rviz to run with Ogre 1.7 rather than Ogre 1.8+.
-  # Some details here: https://github.com/ros-visualization/rviz/issues/782
-  if [ -d src/rviz ]; then
-    pushd src/rviz/ogre_media/models
-    curl https://raw.githubusercontent.com/ros-visualization/rviz/hydro-devel/ogre_media/models/rviz_cone.mesh > rviz_cone.mesh
-    curl https://raw.githubusercontent.com/ros-visualization/rviz/hydro-devel/ogre_media/models/rviz_cube.mesh > rviz_cube.mesh
-    curl https://raw.githubusercontent.com/ros-visualization/rviz/hydro-devel/ogre_media/models/rviz_cylinder.mesh > rviz_cylinder.mesh
-    curl https://raw.githubusercontent.com/ros-visualization/rviz/hydro-devel/ogre_media/models/rviz_sphere.mesh > rviz_sphere.mesh
-    popd
-  fi
 
   # This patch originates from here: https://github.com/ros/catkin/pull/784
   if [ -d src/catkin ]; then
@@ -156,8 +149,8 @@ do_install()
   catkin config --install  --install-space ${ROS_INSTALL_DIR} --cmake-args \
     -DCATKIN_ENABLE_TESTING=1 \
     -DCMAKE_BUILD_TYPE=Release \
-    -DPYTHON_LIBRARY=$(python -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
-    -DPYTHON_INCLUDE_DIR=$(python -c "import sys; print sys.prefix")/include/python2.7
+    -DPYTHON_LIBRARY=$(python2 -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
+    -DPYTHON_INCLUDE_DIR=$(python2 -c "import sys; print sys.prefix")/include/python2.7
   catkin build --limit-status-rate 1
   popd
 

--- a/install
+++ b/install
@@ -100,6 +100,9 @@ do_install()
   brew install qt5 pyqt5 sip
   brew link qt5 --force
 
+  # Get homebrew's opencv3 from a bottle so that we don't have to build it.
+  brew install opencv3
+
   # Mock out python and pip so that we get the brewed versions when rosdep and other programs call them.
   export PATH=$(pwd)/shim:$PATH
 
@@ -146,7 +149,7 @@ do_install()
   fi
 
   # Parallel build.
-  catkin config --install  --install-space ${ROS_INSTALL_DIR} --cmake-args \
+  catkin config --install  --install-space ${ROS_INSTALL_DIR} --blacklist opencv3 --cmake-args \
     -DCATKIN_ENABLE_TESTING=1 \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_FIND_FRAMEWORK=LAST \

--- a/install
+++ b/install
@@ -149,6 +149,7 @@ do_install()
   catkin config --install  --install-space ${ROS_INSTALL_DIR} --cmake-args \
     -DCATKIN_ENABLE_TESTING=1 \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_FIND_FRAMEWORK=LAST \
     -DPYTHON_LIBRARY=$(python2 -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
     -DPYTHON_INCLUDE_DIR=$(python2 -c "import sys; print sys.prefix")/include/python2.7
   catkin build --limit-status-rate 1

--- a/install
+++ b/install
@@ -96,9 +96,17 @@ do_install()
   brew install libyaml || true
   pip2 install -U setuptools rosdep rosinstall_generator wstool rosinstall catkin_tools bloom empy sphinx pycurl
 
-  # Rosdep has an issue detecting that qt5 is correctly installed, so preinstall it.
+  # Rosdep has an issue detecting that qt5 is correctly installed, so preinstall it. This is a keg-only formula,
+  # so add its location to the prefix path in order for workspace packages to be able to find it.
   brew install qt5 pyqt5 sip
-  brew link qt5 --force
+  export CMAKE_PREFIX_PATH=$(brew --prefix qt5)
+
+  # This hack is required to make qt_gui_cpp compile correctly. See https://github.com/mikepurvis/ros-install-osx/pull/84#issuecomment-338209466
+  pushd /usr/local/share/sip
+  if [ ! -e PyQt5 ]; then
+    ln -s Qt5 PyQt5
+  fi
+  popd
 
   # Get homebrew's opencv3 from a bottle so that we don't have to build it.
   brew install opencv3

--- a/install
+++ b/install
@@ -177,7 +177,7 @@ do_install()
       -DCATKIN_ENABLE_TESTING=1 \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_FIND_FRAMEWORK=LAST \
-      -DPYTHON_EXECUTABE=$(which python2) \
+      -DPYTHON_EXECUTABLE=$(which python2) \
       -DPYTHON_LIBRARY=$(python2 -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
       -DPYTHON_INCLUDE_DIR=$(python2 -c "import sys; print sys.prefix")/include/python2.7
   catkin build --limit-status-rate 1

--- a/install
+++ b/install
@@ -137,10 +137,17 @@ do_install()
   rosinstall_generator ${ROS_CONFIGURATION} ${ROS_EXTRA_PACKAGES} --rosdistro ${ROS_DISTRO} --deps --tar > ${WS}.rosinstall
   wstool init -j8 src ${WS}.rosinstall
 
-  # This patch originates from here: https://github.com/ros/catkin/pull/784
+  # This patch originates from: https://github.com/ros/catkin/pull/784
   if [ -d src/catkin ]; then
     pushd src/catkin/cmake
     curl https://raw.githubusercontent.com/ros/catkin/8a47f4eceb4954beb4a5b38b50793d0bbe2c96cf/cmake/catkinConfig.cmake.in > catkinConfig.cmake.in
+    popd
+  fi
+
+  # This patch originates from: https://github.com/ros-visualization/rviz/pull/1165
+  if [ -d src/rviz ]; then
+    pushd src/rviz
+    curl https://raw.githubusercontent.com/mikepurvis/rviz/21eac2bcc061bb623fd17aa449f6215c493b27f2/CMakeLists.txt > CMakeLists.txt
     popd
   fi
 
@@ -159,7 +166,6 @@ do_install()
   # Parallel build.
   catkin config --install  --install-space ${ROS_INSTALL_DIR} \
     --blacklist opencv3 \
-    --make-args CXXFLAGS=-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0 \
     --cmake-args \
       -DCATKIN_ENABLE_TESTING=1 \
       -DCMAKE_BUILD_TYPE=Release \

--- a/install
+++ b/install
@@ -157,12 +157,15 @@ do_install()
   fi
 
   # Parallel build.
-  catkin config --install  --install-space ${ROS_INSTALL_DIR} --blacklist opencv3 --cmake-args \
-    -DCATKIN_ENABLE_TESTING=1 \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_FIND_FRAMEWORK=LAST \
-    -DPYTHON_LIBRARY=$(python2 -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
-    -DPYTHON_INCLUDE_DIR=$(python2 -c "import sys; print sys.prefix")/include/python2.7
+  catkin config --install  --install-space ${ROS_INSTALL_DIR} \
+    --blacklist opencv3 \
+    --make-args CXXFLAGS=-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0 \
+    --cmake-args \
+      -DCATKIN_ENABLE_TESTING=1 \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_FIND_FRAMEWORK=LAST \
+      -DPYTHON_LIBRARY=$(python2 -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
+      -DPYTHON_INCLUDE_DIR=$(python2 -c "import sys; print sys.prefix")/include/python2.7
   catkin build --limit-status-rate 1
   popd
 

--- a/install
+++ b/install
@@ -77,7 +77,7 @@ do_install()
   fi
 
   # Brewed Python
-  if [ $(which python2) != "/usr/local/bin/python2" ]; then
+  if [ ! "$(which python2)" = "/usr/local/bin/python2" ]; then
     brew install python
     mkdir -p ~/Library/Python/2.7/lib/python/site-packages
     echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
@@ -112,6 +112,7 @@ do_install()
   brew install opencv3
 
   # Mock out python and pip so that we get the brewed versions when rosdep and other programs call them.
+  # Mock out pip so that we get the brewed pip2 when rosdep calls it to make an installation.
   export PATH=$(pwd)/shim:$PATH
 
   # Initialize and update rosdep
@@ -131,28 +132,34 @@ do_install()
     rm -rf "$WS"
   fi
   mkdir $WS
-  pushd $WS
+  cd $WS
 
   # Standard source install
   rosinstall_generator ${ROS_CONFIGURATION} ${ROS_EXTRA_PACKAGES} --rosdistro ${ROS_DISTRO} --deps --tar > ${WS}.rosinstall
-  wstool init -j8 src ${WS}.rosinstall
+  wstool init src
+  pushd src
+    # Avoid downloading opencv3; we already installed it from homebrew.
+    wstool merge file://$(pwd)/../${WS}.rosinstall
+    wstool remove opencv3
+    wstool update -j8
 
-  # This patch originates from: https://github.com/ros/catkin/pull/784
-  if [ -d src/catkin ]; then
-    pushd src/catkin/cmake
-    curl https://raw.githubusercontent.com/ros/catkin/8a47f4eceb4954beb4a5b38b50793d0bbe2c96cf/cmake/catkinConfig.cmake.in > catkinConfig.cmake.in
-    popd
-  fi
+    # This patch originates from: https://github.com/ros/catkin/pull/784
+    if [ -d catkin ]; then
+      pushd catkin/cmake
+        curl https://raw.githubusercontent.com/ros/catkin/8a47f4eceb4954beb4a5b38b50793d0bbe2c96cf/cmake/catkinConfig.cmake.in > catkinConfig.cmake.in
+      popd
+    fi
 
-  # This patch originates from: https://github.com/ros-visualization/rviz/pull/1165
-  if [ -d src/rviz ]; then
-    pushd src/rviz
-    curl https://raw.githubusercontent.com/mikepurvis/rviz/21eac2bcc061bb623fd17aa449f6215c493b27f2/CMakeLists.txt > CMakeLists.txt
-    popd
-  fi
+    # This patch originates from: https://github.com/ros-visualization/rviz/pull/1165
+    if [ -d rviz ]; then
+      pushd rviz
+        curl https://raw.githubusercontent.com/mikepurvis/rviz/21eac2bcc061bb623fd17aa449f6215c493b27f2/CMakeLists.txt > CMakeLists.txt
+      popd
+    fi
 
-  # Package dependencies.
-  rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no --skip-keys=python-qt-bindings-qwt5
+    # Package dependencies.
+    rosdep install --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} -y --as-root pip:no
+  popd
 
   # Clean out or create the install directory.
   if [ -d ${ROS_INSTALL_DIR} ]; then
@@ -164,16 +171,16 @@ do_install()
   fi
 
   # Parallel build.
-  catkin config --install  --install-space ${ROS_INSTALL_DIR} \
-    --blacklist opencv3 \
+  catkin config --install \
+    --install-space ${ROS_INSTALL_DIR} \
     --cmake-args \
       -DCATKIN_ENABLE_TESTING=1 \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_FIND_FRAMEWORK=LAST \
+      -DPYTHON_EXECUTABE=$(which python2) \
       -DPYTHON_LIBRARY=$(python2 -c "import sys; print sys.prefix")/lib/libpython2.7.dylib \
       -DPYTHON_INCLUDE_DIR=$(python2 -c "import sys; print sys.prefix")/include/python2.7
   catkin build --limit-status-rate 1
-  popd
 
   echo "Installation successful, please source the ROS workspace:"
   echo

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -1,7 +1,15 @@
-gazebo:
+libogre-dev:
   osx:
     homebrew:
-      packages: [gazebo7]
+      packages: [ogre1.9]
+libpng-dev:
+  osx:
+    homebrew:
+      packages: [libpng]
+libwebp-dev:
+  osx:
+    homebrew:
+      packages: [webp]
 python:
   osx:
     homebrew:
@@ -10,21 +18,72 @@ python:
       packages: [pip, setuptools, nose]
 python-imaging:
   osx:
-    homebrew:
-      packages: [homebrew/python/pillow]
+    pip:
+      packages: [pillow]
 python-matplotlib:
   osx:
     homebrew:
-      packages: [homebrew/python/matplotlib]
+      packages: [homebrew/science/matplotlib]
 python-numpy:
   osx:
     homebrew:
-      packages: [homebrew/python/numpy]
-python-scapy:
-  osx:
-    homebrew:
-      packages: [homebrew/python/scapy]
+      packages: [numpy]
 python-scipy:
   osx:
     homebrew:
-      packages: [homebrew/python/scipy]
+      packages: [scipy]
+python-wxtools:
+  osx:
+    homebrew:
+      packages: [wxmac]
+
+# Use Gazebo 8 instead of 7.
+gazebo7:
+  osx:
+    homebrew:
+      packages: [gazebo8]
+libgazebo7-dev:
+  osx:
+    homebrew:
+      packages: [gazebo8]
+
+libqt5-opengl-dev:
+  osx:
+    homebrew:
+      packages: []
+libqt5-opengl:
+  osx:
+    homebrew:
+      packages: []
+libqt5-core:
+  osx:
+    homebrew:
+      packages: []
+python-qt5-bindings-gl:
+  osx:
+    homebrew:
+      packages: []
+python-qt5-bindings-webkit:
+  osx:
+    homebrew:
+      packages: []
+libqt5-gui:
+  osx:
+    homebrew:
+      packages: []
+libqt5-widgets:
+  osx:
+    homebrew:
+      packages: []
+qtbase5-dev:
+  osx:
+    homebrew:
+      packages: []
+qt5-qmake:
+  osx:
+    homebrew:
+      packages: []
+python-qt5-bindings:
+  osx:
+    homebrew:
+      packages: []

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -14,6 +14,12 @@ libgazebo7-dev:
     homebrew:
       packages: [gazebo8]
 
+# Don't try to install opencv3
+opencv3:
+  osx:
+    homebrew:
+      packages: []
+
 # Installing all this Python stuff from homebrew instead of pip
 # means we get pre-built bottles and don't have to build it all
 # each time.

--- a/rosdeps.yaml
+++ b/rosdeps.yaml
@@ -1,25 +1,28 @@
+# Override the default key to get us Ogre 1.9 instead of 1.7.
 libogre-dev:
   osx:
     homebrew:
       packages: [ogre1.9]
-libpng-dev:
+
+# Use Gazebo 8 instead of 7.
+gazebo7:
   osx:
     homebrew:
-      packages: [libpng]
-libwebp-dev:
+      packages: [gazebo8]
+libgazebo7-dev:
   osx:
     homebrew:
-      packages: [webp]
+      packages: [gazebo8]
+
+# Installing all this Python stuff from homebrew instead of pip
+# means we get pre-built bottles and don't have to build it all
+# each time.
 python:
   osx:
     homebrew:
       packages: [python]
     pip:
       packages: [pip, setuptools, nose]
-python-imaging:
-  osx:
-    pip:
-      packages: [pillow]
 python-matplotlib:
   osx:
     homebrew:
@@ -37,16 +40,7 @@ python-wxtools:
     homebrew:
       packages: [wxmac]
 
-# Use Gazebo 8 instead of 7.
-gazebo7:
-  osx:
-    homebrew:
-      packages: [gazebo8]
-libgazebo7-dev:
-  osx:
-    homebrew:
-      packages: [gazebo8]
-
+# Zero out all the QT5 keys. We'll install it ourselves upfront.
 libqt5-opengl-dev:
   osx:
     homebrew:

--- a/shim/pip
+++ b/shim/pip
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This wrapper allows rosdep to call pip and it actually be
+# the pip2 that's part of brewed Python, rather than the missing
+# system pip.
+pip2 $@
+exit $?

--- a/shim/python
+++ b/shim/python
@@ -1,5 +1,0 @@
-#!/bin/sh
-# This wrapper allows scripts to call python and it actually be
-# the python2 that's brewed Python, rather than system python.
-python2 $@
-exit $?

--- a/shim/python
+++ b/shim/python
@@ -1,0 +1,5 @@
+#!/bin/sh
+# This wrapper allows scripts to call python and it actually be
+# the python2 that's brewed Python, rather than system python.
+python2 $@
+exit $?


### PR DESCRIPTION
A bunch of issues have accumulated here around how to build ROS with Homebrew now that they've made the following changes:

- QT4 is no longer a thing.
- QT5 is a "keg only" formula.
- The brewed `python` formula now supplies `bin/python2` but not `bin/python` (and likewise with `pip2`/`pip`).

I'm putting up the PR as a work in progress for interested parties to hack on. The current state of affairs is that the build dies at `qt_qui_cpp` due to sip/shiboken shenanigans, and it dies at `opencv3` if and only if QT5 is force-linked (should we just install the homebrew opencv3 bottle?), and if you make it past all that, `nodelet_tutorial_math` has C++11 ABI issues:

```
Errors     << nodelet_tutorial_math:make /Users/mikepurvis/ros-install-osx/lunar_desktop_full_ws/logs/nodelet_tutorial_math/build.make.000.log
In file included from /Users/mikepurvis/ros-install-osx/lunar_desktop_full_ws/src/common_tutorials/nodelet_tutorial_math/src/plus.cpp:30:
In file included from /opt/ros/lunar/include/pluginlib/class_list_macros.h:40:
In file included from /opt/ros/lunar/include/class_loader/class_loader.h:33:
In file included from /usr/local/include/boost/shared_ptr.hpp:17:
In file included from /usr/local/include/boost/smart_ptr/shared_ptr.hpp:23:
In file included from /usr/local/include/boost/config/no_tr1/memory.hpp:21:
In file included from /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/memory:610:
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cstring:79:9: error: no member named 'strcoll' in the global namespace
using ::strcoll;
      ~~^
```

This failure looks like it has a solution via the discussion in #73.