### PR TITLE
Removed `brew install caskroom` line that fails

### DIFF
--- a/install
+++ b/install
@@ -42,7 +42,6 @@ do_install()
 
   # XQuartz
   if ! hash xquartz 2>/dev/null; then
-    brew install caskroom/cask/brew-cask
     brew cask install xquartz
     echo "Log out and in to finalize XQuartz setup."
     exit 0


### PR DESCRIPTION
see:
https://github.com/Homebrew/homebrew-cask/issues/35645

Error message

> Updating Homebrew...
> Error: caskroom/cask was moved. Tap homebrew/cask instead.